### PR TITLE
fix options assignment (#11)

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function koaBetterRatelimit (opts) {
       duration: 1000 * 60 * 60 * 24,
       limited: 'Too Many Requests',
       max: 500
-    }, options)
+    }, opts)
 
     const id = ctx.identifier
     const data = store[id]


### PR DESCRIPTION
User-specified `opts` can once again override default `options`.

Thanks for reviewing!